### PR TITLE
Set _autocommit from argument

### DIFF
--- a/graphdb/SQLiteGraphDB/__init__.py
+++ b/graphdb/SQLiteGraphDB/__init__.py
@@ -124,7 +124,7 @@ class SQLiteGraphDB(object):
             self._create_file(path)
         self._state = read_write_state_machine()
         self._autostore = True
-        self._autocommit = True
+        self._autocommit = autocommit
         self._path = path
         self._connections = better_default_dict(lambda s=self:sqlite3.connect(s._path))
         self._cursors = better_default_dict(lambda s=self:s.conn.cursor())


### PR DESCRIPTION
On SQLiteGraphDB, `_autocommit` is always being set to True independent of what the `autocommit` value when initializing it. This small change is just to use the value